### PR TITLE
Update rx-firebase.js

### DIFF
--- a/src/rx-firebase.js
+++ b/src/rx-firebase.js
@@ -143,7 +143,7 @@ function unpackSnapShot(snapShot, prev, eventType, options) {
 }
 
 function wrapValue(val, options) {
-  if (Object.isExtensible(val)) {
+  if (val && Object.isExtensible(val)) {
     return val;
   }
 


### PR DESCRIPTION
fixed error when observing on non-existing firebase node. firebase returns null when calling snapshot.val(), this small fix keeps this behavior